### PR TITLE
Handle missing extra fields

### DIFF
--- a/src/circle-builds
+++ b/src/circle-builds
@@ -27,8 +27,7 @@ def _extract_custom_fields(build, fields):
                 print("Failed to access '{}' in\n{}"
                       .format(field, pretty_string), file=sys.stderr)
                 sys.exit(1)
-        if obj is not None:
-            output.append(obj)
+        output.append(obj or 'null')
     return output
 
 


### PR DESCRIPTION
When using`circle builds -f <field>`, it's possible for the field to be non-null on some builds, but null on others. This change changes `_extract_custom_fields()` to use the string `null` for those fields. This prevents a down stream crash in [`formatter`](https://github.com/keith/circle-cli/blob/f3191450a32acc6083156aebc9151297ad41fc72/src/helpers/formatter.py#L15) when it encounters a row with less columns than it expects.

For example, running this command:

```
circle builds -f lifecycle outcome
```

Will crash for builds that have no `outcome` field.
